### PR TITLE
Add swift-format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,4 @@ fastlane/FastlaneRunner
 Info.plist
 projxcuserdata
 workspacexcuserdata
+swift-format

--- a/setup.sh
+++ b/setup.sh
@@ -2,6 +2,7 @@
 set -e
 
 PROJECT_NAME="Mocka"
+SWIFT_FORMAT_VERSION="swift-5.3-branch"
 
 # Install Homebrew dependency manager.
 if ! [[ -x "$(command -v brew)" ]]; then
@@ -15,6 +16,38 @@ if ! [[ -x "$(command -v xcodegen)" ]]; then
   brew install xcodegen
 fi
 
+# Install Swift Format on the current working directory.
+if [[ ! -d "swift-format" ]]; then
+  echo 'swift-format is not installed.' >&2
+
+  CURRENT_WORKING_DIRECTORY=$(pwd)
+
+  git clone -b $SWIFT_FORMAT_VERSION https://github.com/apple/swift-format.git
+  cd swift-format
+  swift build
+
+  cd ..
+else
+  echo "Check if swift-format version is $SWIFT_FORMAT_VERSION." >&2
+
+  cd swift-format
+
+  CURRENT_BRANCH=$(git branch --show-current)
+
+  # If it's already installed, check that it's the right version.
+  if [[ $CURRENT_BRANCH != $SWIFT_FORMAT_VERSION ]]; then
+    echo "Installing swift-format $SWIFT_FORMAT_VERSION version." >&2
+    git fetch --all
+    git checkout --track origin/$SWIFT_FORMAT_VERSION || git checkout $SWIFT_FORMAT_VERSION
+
+    swift build
+  else
+    echo "swift-format $SWIFT_FORMAT_VERSION already installed." >&2
+  fi
+
+  cd ..
+fi
+
 for var in $@
 do
   # If argument "close" is passed, close the project.
@@ -23,13 +56,10 @@ do
     osascript -e 'tell app "Xcode" to quit'
   fi
 
-  # If argument "format" is passed, format all the code by using swift-format.
+    # If argument "format" is passed, format all the code by using swift-format.
   if [[ "$var" == "format" ]]; then
-    echo -e "Formatting code..."
-
-    if [[ -x "$(command -v swift-format)" ]]; then
-      swift-format --configuration swiftformat.json -m format -r -i ./
-    fi
+    # Run local swift-format
+    ./swift-format/.build/x86_64-apple-macosx/debug/swift-format --configuration swiftformat.json -m format -r -i ./
   fi
 done
 
@@ -37,20 +67,20 @@ done
 mkdir -p .temp
 
 # Move the project userdata folder to a temporary folder.
-if ls *.xcodeproj/xcuserdata 1> /dev/null 2>&1; then
-  mv *.xcodeproj/xcuserdata .temp/projxcuserdata
+if ls $PROJECT_NAME.xcodeproj/xcuserdata 1> /dev/null 2>&1; then
+  mv $PROJECT_NAME.xcodeproj/xcuserdata .temp/projxcuserdata
 fi
 
 # Remove present .xcodeproj.
-rm -rf *.xcodeproj
+rm -rf $PROJECT_NAME.xcodeproj
 
 # Run xcodegen to generate a new project file.
 xcodegen
 
 # Move back the project userdata folder to the correct folder.
-if ls projxcuserdata 1> /dev/null 2>&1; then
-  mv .temp/projxcuserdata *.xcodeproj/
-  mv *.xcodeproj/projxcuserdata $PROJECT_NAME.xcodeproj/xcuserdata
+if ls .temp/projxcuserdata 1> /dev/null 2>&1; then
+  mv .temp/projxcuserdata $PROJECT_NAME.xcodeproj/
+  mv $PROJECT_NAME.xcodeproj/projxcuserdata $PROJECT_NAME.xcodeproj/xcuserdata
 fi
 
 # Remove the temporary folder.


### PR DESCRIPTION
This PR adds the official `swift-format` package by cloning it from `git` to the root folder of the project. The `swift-format` folder has also been added to the `.gitignore`.

By using the `SWIFT_FORMAT_VERSION` variable we will be able to switch between its versions automatically.