### PR TITLE
Add `BufferedSubject`

### DIFF
--- a/Sources/Server/Helpers/BufferedSubject.swift
+++ b/Sources/Server/Helpers/BufferedSubject.swift
@@ -15,13 +15,13 @@ public class BufferedSubject<Output, Failure: Error> {
   private var buffer: [Output]
   
   /// The max size of the buffer.
+  /// This dictates the maximum number of elements to include in the buffer.
   private let bufferSize: Int
   
   // MARK: - Init
   
   /// Creates an instance of `BufferedSubject`.
-  /// - Parameter bufferSize: The buffer size.
-  ///                         Defaults to `.max`.
+  /// - Parameter bufferSize: The buffer size. Defaults to `.max`.
   /// - Note: A huge buffer size could
   public init(bufferSize: Int = .max) {
     self.bufferSize = bufferSize
@@ -49,9 +49,10 @@ extension BufferedSubject: Subject {
   /// Sends a value to the subscriber.
   /// - Parameter value: The value to send.
   public func send(_ value: Output) {
-    if buffer.count > bufferSize - 1{
+    if buffer.count > bufferSize - 1 {
       buffer.remove(at: 0)
     }
+
     buffer.append(value)
     passthroughSubject.send(value)
   }

--- a/Tests/ServerTests/BufferedSubjectTests.swift
+++ b/Tests/ServerTests/BufferedSubjectTests.swift
@@ -3,6 +3,7 @@ import XCTest
 @testable import Server
 
 class BufferedSubjectTests: XCTestCase {
+  /// Tests the right fetch of values from a `BufferedSubject`.
   func testBufferedSubject() {
     let bufferedSubject = BufferedSubject<Int, Never>()
     
@@ -29,6 +30,7 @@ class BufferedSubjectTests: XCTestCase {
     }
   }
   
+  /// Tests the right fetch of values from a `BufferedSubject` with a buffer size that is less than the sended values.
   func testBufferedSubjectWithBufferSize() {
     let bufferedSubject = BufferedSubject<Int, Never>(bufferSize: 1)
     
@@ -55,6 +57,7 @@ class BufferedSubjectTests: XCTestCase {
     }
   }
   
+  // Tests the empty fetch of values from a `BufferedSubject` by calling the `clearBuffer()` function.
   func testBufferedSubjectWithClearBuffer() {
     let bufferedSubject = BufferedSubject<Int, Never>(bufferSize: 1)
     


### PR DESCRIPTION
Added `BufferedSubject` to allow buffering of output values.
Added UTs.
This subject will be useful to buffer values, this way when a subscriber subscribes to it, receive all the buffered values.
This could be useful for both `networkExchangesSubject` and `consoleLogsSubject` because, at the time the UI is created,  the server may have already sent values. Using a normal `BehaviourSubject` will result in losing these events.