### PR TITLE
Improve swift-format Integration

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -58,6 +58,7 @@ do
 
     # Run local swift-format.
     swift run swift-format --configuration ../swiftformat.json -m format -r -i ./../Sources
+    swift run swift-format --configuration ../swiftformat.json -m format -r -i ./../Tests
 
     cd ..
   fi

--- a/swiftformat.json
+++ b/swiftformat.json
@@ -7,7 +7,7 @@
   },
   "indentConditionalCompilationBlocks" : true,
   "indentSwitchCaseLabels" : false,
-  "lineBreakAroundMultilineExpressionChainComponents" : false,
+  "lineBreakAroundMultilineExpressionChainComponents" : true,
   "lineBreakBeforeControlFlowKeywords" : false,
   "lineBreakBeforeEachArgument" : false,
   "lineBreakBeforeEachGenericRequirement" : false,


### PR DESCRIPTION
This PR just improve the `swift-format` integration by using `swift run` instead of the executable path.
It also installs `swift-format` only if you type `format` as a parameter of `setup.sh`.