### PR TITLE
Add local Git repository creation

### DIFF
--- a/Sources/App/Views/Sections/Settings/Server/ServerSettings.swift
+++ b/Sources/App/Views/Sections/Settings/Server/ServerSettings.swift
@@ -95,7 +95,7 @@ struct ServerSettings: View {
       VStack(alignment: .trailing) {
         Button(
           action: {
-            viewModel.confirmSettings(with: presentationMode, shouldCreateGitRepository: viewModel.isGitRepositoryCreationEnabled)
+            viewModel.confirmSettings(with: presentationMode)
           },
           label: {
             Text("OK")

--- a/Sources/App/Views/Sections/Settings/Server/ServerSettings.swift
+++ b/Sources/App/Views/Sections/Settings/Server/ServerSettings.swift
@@ -81,12 +81,21 @@ struct ServerSettings: View {
           RoundedTextField(title: "Server port", text: $viewModel.port)
             .frame(width: 300)
         }
+        
+        HStack {
+          Toggle(isOn: $viewModel.isGitRepositoryCreationEnabled) {
+            Text("Create Git Repository")
+          }
+          .disabled(viewModel.isGitRepositoryAlreadyCreated)
+          .padding(.top, 10)
+          .padding(.leading, 128)
+        }
       }
-
+            
       VStack(alignment: .trailing) {
         Button(
           action: {
-            viewModel.confirmSettings(with: presentationMode)
+            viewModel.confirmSettings(with: presentationMode, shouldCreateGitRepository: viewModel.isGitRepositoryCreationEnabled)
           },
           label: {
             Text("OK")

--- a/Sources/App/Views/Sections/Settings/Server/ServerSettingsViewModel.swift
+++ b/Sources/App/Views/Sections/Settings/Server/ServerSettingsViewModel.swift
@@ -113,10 +113,8 @@ final class ServerSettingsViewModel: ObservableObject {
   /// Confirms the selected startup settings
   /// by creating the configuration file in the right path.
   /// In case of error the `workspaceURL` returns to `nil`.
-  /// - Parameters:
-  ///  - presentationMode: The `View` `PresentationMode`.
-  ///  - shouldCreateGitRepository: Whether or not the Git repo should be created.
-  func confirmSettings(with presentationMode: Binding<PresentationMode>, shouldCreateGitRepository: Bool) {
+  /// - Parameter presentationMode: The `View` `PresentationMode`.
+  func confirmSettings(with presentationMode: Binding<PresentationMode>) {
     let workspaceURL = URL(fileURLWithPath: workspacePath)
 
     do {
@@ -127,7 +125,7 @@ final class ServerSettingsViewModel: ObservableObject {
         ServerConnectionConfiguration(hostname: hostname, port: Int(port) ?? 8080)
       )
       
-      if shouldCreateGitRepository {
+      if isGitRepositoryCreationEnabled {
         try createGitRepository(from: workspaceURL)
       }
       

--- a/Sources/App/Views/Sections/Settings/Server/ServerSettingsViewModel.swift
+++ b/Sources/App/Views/Sections/Settings/Server/ServerSettingsViewModel.swift
@@ -124,7 +124,7 @@ final class ServerSettingsViewModel: ObservableObject {
       try Logic.Settings.updateServerConfigurationFile(
         ServerConnectionConfiguration(hostname: hostname, port: Int(port) ?? 8080)
       )
-      
+
       if isGitRepositoryCreationEnabled {
         try createGitRepository(from: workspaceURL)
       }

--- a/Sources/App/Views/Sections/Settings/Server/ServerSettingsViewModel.swift
+++ b/Sources/App/Views/Sections/Settings/Server/ServerSettingsViewModel.swift
@@ -57,11 +57,19 @@ final class ServerSettingsViewModel: ObservableObject {
 
   /// Whether the `fileImporter` is presented.
   @Published var fileImporterIsPresented: Bool = false
+  
+  /// Whether or not the git repo creation checkbox is enabled.
+  @Published var isGitRepositoryCreationEnabled: Bool = false
 
   /// The value of the workspace path.
   /// When this value is updated, the value in the user defaults is updated as well.
   @AppStorage(UserDefaultKey.workspaceURL) private var workspaceURL: URL?
-
+  
+  /// Whether or not the workspace git repository already exists.
+  var isGitRepositoryAlreadyCreated: Bool {
+    FileManager.default.fileExists(atPath: workspacePath.appending("/.git"))
+  }
+    
   // MARK: - Init
 
   /// Creates the `ServerSettingsViewModel`.
@@ -105,8 +113,10 @@ final class ServerSettingsViewModel: ObservableObject {
   /// Confirms the selected startup settings
   /// by creating the configuration file in the right path.
   /// In case of error the `workspaceURL` returns to `nil`.
-  /// - Parameter presentationMode: The `View` `PresentationMode`.
-  func confirmSettings(with presentationMode: Binding<PresentationMode>) {
+  /// - Parameters:
+  ///  - presentationMode: The `View` `PresentationMode`.
+  ///  - shouldCreateGitRepository: Whether or not the Git repo should be created.
+  func confirmSettings(with presentationMode: Binding<PresentationMode>, shouldCreateGitRepository: Bool) {
     let workspaceURL = URL(fileURLWithPath: workspacePath)
 
     do {
@@ -116,7 +126,11 @@ final class ServerSettingsViewModel: ObservableObject {
       try Logic.Settings.updateServerConfigurationFile(
         ServerConnectionConfiguration(hostname: hostname, port: Int(port) ?? 8080)
       )
-
+      
+      if shouldCreateGitRepository {
+        try createGitRepository(from: workspaceURL)
+      }
+      
       if isShownFromSettings {
         // Currently we can't close a window from SwiftUI.
         NSApplication.shared.keyWindow?.close()
@@ -132,5 +146,17 @@ final class ServerSettingsViewModel: ObservableObject {
       self.workspaceURL = nil
       self.workspacePathError = workspacePathError
     }
+  }
+  
+  /// Creates a local git repository in the workspace `URL`.
+  /// - parameter workspaceURL: The workspace `URL`.
+  private func createGitRepository(from workspaceURL: URL) throws {
+    let task = Process()
+    let command = "git init /\(workspaceURL.pathComponents.dropFirst().joined(separator: "/"))"
+    task.launchPath = "bin/bash"
+    task.arguments = ["-c", command]
+    
+    try task.run()
+    task.waitUntilExit()
   }
 }


### PR DESCRIPTION
# Description

This PR adds the possibility to create a git local repository when selecting a workspace, if a `.git` folder does not already exist.

Implements #77 

## Type of Change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [X] Manually tested

**Configuration**:
OS and Version: macOS 11.2.3

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

# Screenshots

| Add git repo selected | Add git repo unavailable |
|------|------|
|<img width="582" src="https://user-images.githubusercontent.com/48313283/115752877-d3490080-a39a-11eb-8ee6-67a51d0c6fc4.png">|<img width="584" src="https://user-images.githubusercontent.com/48313283/115752884-d47a2d80-a39a-11eb-9a6a-f670b0f3c70a.png">|
