### PR TITLE
Create initial workspace folder in settings if needed

### DIFF
--- a/Sources/App/Logic/WorkspacePath+Logic.swift
+++ b/Sources/App/Logic/WorkspacePath+Logic.swift
@@ -36,9 +36,39 @@ extension Logic.WorkspacePath {
       throw MockaError.workspacePathNotFolder
     }
   }
+
+  /// Checks if a folder exists in the given path.
+  /// Creates the folder if it does not exist.
+  /// - Parameter path: The path in wich we want the folder.
+  static func checkPathAndCreateFolderIfNeeded(_ path: String) throws {
+    do {
+      try Self.isFolder(URL(fileURLWithPath: path))
+    } catch MockaError.workspacePathDoesNotExist {
+      // Try to create the folder if it does not exist.
+      do {
+        try Self.createFolder(path)
+      } catch {
+        throw error
+      }
+
+    } catch {
+      throw error
+    }
+  }
 }
 
 private extension Logic.WorkspacePath {
+  /// Create a folder in the given path.
+  /// - Parameter path: The path in wich we want the folder.
+  /// - Throws: `MockaError.failedToCreateDirectory(path:)`.
+  static func createFolder(_ path: String) throws {
+    do {
+      try FileManager.default.createDirectory(atPath: path, withIntermediateDirectories: true, attributes: nil)
+    } catch {
+      throw MockaError.failedToCreateDirectory(path: path)
+    }
+  }
+
   /// Checks if a resource exists at a given `URL`'s path.
   /// - Parameter url: The `URL` of the resource.
   /// - Returns: Returns `true` if the resource is a folder, otherwise `false`.

--- a/Sources/App/Models/MockaError.swift
+++ b/Sources/App/Models/MockaError.swift
@@ -21,6 +21,9 @@ enum MockaError: Error {
   /// An error occurred when trying to encode a file.
   case failedToEncode
 
+  /// An error occurred trying to unwrap an optional URL.
+  case failedToUnwrapURL
+
   /// Could not create directory at request path.
   /// The path is passed included with the error.
   case failedToCreateDirectory(path: String)

--- a/Sources/App/Models/MockaError.swift
+++ b/Sources/App/Models/MockaError.swift
@@ -5,7 +5,7 @@
 import Foundation
 
 /// A list of errors that can be thrown inside of `Mocka` app.
-enum MockaError: Error {
+enum MockaError: Error, Equatable {
   /// The workspace path value is missing when it's expected to be populated.
   case missingWorkspacePathValue
 

--- a/Sources/App/Views/Sections/Settings/Server/ServerSettings.swift
+++ b/Sources/App/Views/Sections/Settings/Server/ServerSettings.swift
@@ -37,20 +37,12 @@ struct ServerSettings: View {
             .font(.headline)
             .frame(width: 120, height: 30, alignment: .trailing)
 
-          VStack {
-            RoundedTextField(title: "Workspace folder", text: $viewModel.workspacePath)
-              .frame(width: 300)
-              .overlay(
-                RoundedRectangle(cornerRadius: 6)
-                  .stroke(Color.redEye, lineWidth: viewModel.workspacePathError == nil ? 0 : 1)
-              )
-
-            Text("Please note that the selected folder must exist and it will not be automatically created.")
-              .font(.subheadline)
-              .frame(width: 300, height: 30)
-              .padding(.top, -6)
-              .foregroundColor(.macchiato)
-          }
+          RoundedTextField(title: "Workspace folder", text: $viewModel.workspacePath)
+            .frame(width: 300)
+            .overlay(
+              RoundedRectangle(cornerRadius: 6)
+                .stroke(Color.redEye, lineWidth: viewModel.workspacePathError == nil ? 0 : 1)
+            )
 
           Button("Select folder") {
             viewModel.fileImporterIsPresented.toggle()

--- a/Sources/App/Views/Sections/Settings/Server/ServerSettingsViewModel.swift
+++ b/Sources/App/Views/Sections/Settings/Server/ServerSettingsViewModel.swift
@@ -99,7 +99,7 @@ final class ServerSettingsViewModel: ObservableObject {
     do {
       self.workspaceURL = workspaceURL
 
-      try Logic.WorkspacePath.checkPathAndCreateFolderIfNeeded(workspacePath)
+      try Logic.WorkspacePath.checkURLAndCreateFolderIfNeeded(at: workspaceURL)
       try Logic.Settings.updateServerConfigurationFile(
         ServerConnectionConfiguration(hostname: hostname, port: Int(port) ?? 8080)
       )

--- a/Sources/App/Views/Sections/Settings/Server/ServerSettingsViewModel.swift
+++ b/Sources/App/Views/Sections/Settings/Server/ServerSettingsViewModel.swift
@@ -19,6 +19,9 @@ final class ServerSettingsViewModel: ObservableObject {
   /// it will use the observed `workspaceURL` property.
   @Published var workspacePath: String = UserDefaults.standard.url(forKey: UserDefaultKey.workspaceURL)?.path ?? "" {
     didSet {
+      // When the user modifies the `workspacePath` we must remove any `workspacePathError` if present.
+      // This is needed in order to remove the red `RoundedRectangle` around the `RoundedTextField` of the "Workspace folder" entry.
+      // In this way the red `RoundedRectangle` will be hidden while the user is editing the `workspacePath` in the entry.
       workspacePathError = nil
     }
   }

--- a/Sources/App/Views/Sections/Settings/Server/ServerSettingsViewModel.swift
+++ b/Sources/App/Views/Sections/Settings/Server/ServerSettingsViewModel.swift
@@ -19,7 +19,7 @@ final class ServerSettingsViewModel: ObservableObject {
   /// it will use the observed `workspaceURL` property.
   @Published var workspacePath: String = UserDefaults.standard.url(forKey: UserDefaultKey.workspaceURL)?.path ?? "" {
     didSet {
-      checkURL(workspacePath)
+      workspacePathError = nil
     }
   }
 
@@ -72,22 +72,6 @@ final class ServerSettingsViewModel: ObservableObject {
 
   // MARK: - Functions
 
-  /// Check the validity of the given path.
-  /// - Parameter path: If valid, returns the path.
-  func checkURL(_ path: String) {
-    do {
-      try Logic.WorkspacePath.isFolder(URL(fileURLWithPath: path))
-
-      workspacePathError = nil
-    } catch {
-      guard let workspacePathError = error as? MockaError else {
-        return
-      }
-
-      self.workspacePathError = workspacePathError
-    }
-  }
-
   /// The `fileImporter` completion function.
   /// This function is called once the user selected a folder.
   /// It sets the path in case of success, and the error in case of error.
@@ -112,7 +96,7 @@ final class ServerSettingsViewModel: ObservableObject {
     do {
       self.workspaceURL = workspaceURL
 
-      try Logic.WorkspacePath.isFolder(workspaceURL)
+      try Logic.WorkspacePath.checkPathAndCreateFolderIfNeeded(workspacePath)
       try Logic.Settings.updateServerConfigurationFile(
         ServerConnectionConfiguration(hostname: hostname, port: Int(port) ?? 8080)
       )

--- a/Tests/AppTests/WorkspacePathLogicTests.swift
+++ b/Tests/AppTests/WorkspacePathLogicTests.swift
@@ -1,0 +1,64 @@
+//
+//  Mocka
+//
+
+import UniformTypeIdentifiers
+import XCTest
+
+@testable import MockaApp
+
+class WorkspacePathLogicTests: XCTestCase {
+
+  // MARK: Variables
+
+  // The `URL` of a temporary folder we will use for this test.
+  var temporaryWorkspaceURL: URL!
+
+  // MARK: Set Up and Tear Down
+
+  override func setUp() {
+    // Sets up the `temporaryWorkspaceURL`.
+    temporaryWorkspaceURL = URL(fileURLWithPath: NSTemporaryDirectory().appending("Mocka"))
+  }
+
+  override func tearDown() {
+    // Eventually cleans up any file or folder in the `temporaryWorkspaceURL`.
+    try? FileManager.default.removeItem(at: temporaryWorkspaceURL)
+  }
+
+  // MARK: Tests
+
+  // Test that the unwrapping error is thrown when the URL is not valid.
+  func testWorkspaceURLUnwrapError() throws {
+    XCTAssertThrowsError(try Logic.WorkspacePath.checkURLAndCreateFolderIfNeeded(at: nil)) { error in
+      XCTAssertEqual(error as? MockaError, MockaError.failedToUnwrapURL)
+    }
+  }
+
+  // Test that the logic creates a new folder correctly.
+  func testWorkspaceFolderCreation() throws {
+    try Logic.WorkspacePath.checkURLAndCreateFolderIfNeeded(at: temporaryWorkspaceURL)
+    XCTAssertTrue(FileManager.default.fileExists(atPath: temporaryWorkspaceURL.path))
+    XCTAssertEqual(try? temporaryWorkspaceURL.resourceValues(forKeys: [.contentTypeKey]).contentType, UTType.folder)
+  }
+
+  // Test that the logic uses an already existing folder correctly.
+  func testWorkspaceFolderExisting() throws {
+    try FileManager.default.createDirectory(at: temporaryWorkspaceURL, withIntermediateDirectories: true, attributes: nil)
+
+    try Logic.WorkspacePath.checkURLAndCreateFolderIfNeeded(at: temporaryWorkspaceURL)
+
+    XCTAssertTrue(FileManager.default.fileExists(atPath: temporaryWorkspaceURL.path))
+    XCTAssertEqual(try? temporaryWorkspaceURL.resourceValues(forKeys: [.contentTypeKey]).contentType, UTType.folder)
+  }
+
+  // Test that the right error is thrown when trying to use a file as the workspace folder.
+  func testWorkspacePathContainsFile() throws {
+    FileManager.default.createFile(atPath: temporaryWorkspaceURL.path, contents: nil, attributes: nil)
+
+    XCTAssertThrowsError(try Logic.WorkspacePath.checkURLAndCreateFolderIfNeeded(at: temporaryWorkspaceURL)) { error in
+      XCTAssertEqual(error as? MockaError, MockaError.workspacePathNotFolder)
+    }
+  }
+
+}


### PR DESCRIPTION
# Description

This PR adds the feature to automatically create the initial workspace folder if the inserted one is not already existing.
This fixes this issue: https://github.com/wise-emotions/mocka/issues/76

An explicative video of the implemented feature.
https://user-images.githubusercontent.com/23726138/115762783-1b205580-a3a4-11eb-8e27-9f52c3b507ef.mov

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

- [X] Manually tested
- [X] Automated Unit Test

**Configuration**:
OS and Version: macOS 11.2.3

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
