### PR TITLE
Fix Editor Crash

### DIFF
--- a/Sources/App/Resources/MockaApp.entitlements
+++ b/Sources/App/Resources/MockaApp.entitlements
@@ -2,11 +2,7 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>com.apple.security.app-sandbox</key>
-	<true/>
 	<key>com.apple.security.cs.disable-library-validation</key>
-	<true/>
-	<key>com.apple.security.files.user-selected.read-write</key>
 	<true/>
 	<key>com.apple.security.network.server</key>
 	<true/>

--- a/Sources/App/Views/Sections/Editor/SourceTree/SourceTreeNode.swift
+++ b/Sources/App/Views/Sections/Editor/SourceTree/SourceTreeNode.swift
@@ -13,10 +13,6 @@ struct SourceTreeNode: View {
   /// The name of the file or folder.
   @State var name: String
 
-  /// Whether the `TextField` should become the first responder.
-  /// - Note: This is needed since invoking `becomeFirstResponder` more than once will result in resigning the first responder.
-  @State var shouldBecomeFirstResponder: Bool
-
   /// Whether the node represents a folder or not.
   let isFolder: Bool
 
@@ -47,9 +43,8 @@ struct SourceTreeNode: View {
         )
         .foregroundColor(.latte)
         .introspectTextField { textField in
-          if isRenaming && shouldBecomeFirstResponder {
+          if isRenaming, textField.currentEditor() == nil {
             textField.becomeFirstResponder()
-            shouldBecomeFirstResponder = false
           }
         }
       } else {
@@ -69,7 +64,6 @@ struct SourceTreeNode: View {
   ///   - onRenamed: The closure invoked after renaming the node with the new name.
   init(name: String, isFolder: Bool, isRenaming: Bool = false, onRenamed: ((String) -> Void)? = nil) {
     self.name = name
-    self.shouldBecomeFirstResponder = isRenaming
     self.isFolder = isFolder
     self.isRenaming = isRenaming
     self.onRenamed = onRenamed


### PR DESCRIPTION
# Description

Fixed Editor crash due to `shouldBecomeFirstResponder` property.
Also, remove the unneeded sandbox.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

- [x] Compile the app in `release` mode
- [x] Go to Editor section with at least one API
- [x] The app crashes

**Configuration**:
OS and Version: macOS 11.2
App Version: 0.1.0

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
