### PR TITLE
Add Status Bar Icon with Shortcuts to Start/Stop the Server.

### DIFF
--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -3,11 +3,19 @@
 //
 
 import AppKit
+import SwiftUI
 
 final class AppDelegate: NSObject, NSApplicationDelegate {
+  /// The app environment.
+  @ObservedObject var appEnvironment = AppEnvironment()
+
+  var statusItem: NSStatusItem!
+
   func applicationDidFinishLaunching(_ notification: Notification) {
     // Disable the Tab Bar feature.
     disableTabBar()
+
+    setupStatusItem()
   }
 }
 
@@ -20,5 +28,43 @@ extension AppDelegate {
     }
 
     window.tabbingMode = .disallowed
+  }
+
+  private func setupStatusItem() {
+    // The menu in the `statusItem`.
+    let menu = NSMenu()
+
+    // Use a SwiftUI View as menu.
+    // We can use the appEnvironment to disable not available actions,
+    // but we have experimented some bugs on the tap of the buttons inside the manu view
+    // when the app is in background.
+    let statusItemMenu = StatusItemMenu() { [weak self] in
+      self?.statusItem.menu?.cancelTracking()
+    }
+    .environmentObject(appEnvironment)
+
+    let menuItemView = NSHostingView(rootView: statusItemMenu)
+    // Don't forget to set the frame, otherwise it won't be shown.
+    menuItemView.frame = NSRect(x: 0, y: 0, width: 200, height: 80)
+    let menuItem = NSMenuItem()
+    menuItem.view = menuItemView
+    menu.addItem(menuItem)
+
+    // Old style of menu using AppKit.
+    // We cannot use the appEnvironment in this case.
+    // But there are no bugs on the tap of the items in this way.
+    menu.addItem(withTitle: "Start Server", action: #selector(startServer), keyEquivalent: "")
+    menu.addItem(withTitle: "Stop Server", action: nil, keyEquivalent: "")
+    menu.addItem(withTitle: "Restart Server", action: nil, keyEquivalent: "")
+
+    // StatusItem is stored as a class property.
+    statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
+    statusItem?.menu = menu
+    statusItem.button?.image = #imageLiteral(resourceName: "AppIcon")
+    statusItem.button?.imageScaling = .scaleProportionallyUpOrDown
+  }
+
+  @objc func startServer() {
+    print("Start Server")
   }
 }

--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -38,7 +38,7 @@ extension AppDelegate {
     // We can use the appEnvironment to disable not available actions,
     // but we have experimented some bugs on the tap of the buttons inside the manu view
     // when the app is in background.
-    let statusItemMenu = StatusItemMenu() { [weak self] in
+    let statusItemMenu = StatusItemMenu { [weak self] in
       self?.statusItem.menu?.cancelTracking()
     }
     .environmentObject(appEnvironment)

--- a/Sources/App/Mocka.swift
+++ b/Sources/App/Mocka.swift
@@ -9,9 +9,6 @@ struct Mocka: App {
   /// The `AppDelegate` of the app.
   @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
 
-  /// The app environment.
-  @StateObject private var appEnvironment = AppEnvironment()
-
   var body: some Scene {
     WindowGroup {
       AppSection()
@@ -24,9 +21,9 @@ struct Mocka: App {
           maxHeight: .infinity,
           alignment: .leading
         )
-        .environmentObject(appEnvironment)
+        .environmentObject(appDelegate.appEnvironment)
         .sheet(
-          isPresented: $appEnvironment.shouldShowStartupSettings
+          isPresented: appDelegate.$appEnvironment.shouldShowStartupSettings
         ) {
           ServerSettings(viewModel: ServerSettingsViewModel(isShownFromSettings: false))
         }

--- a/Sources/App/StatusItemMenu.swift
+++ b/Sources/App/StatusItemMenu.swift
@@ -1,0 +1,74 @@
+//
+//  Mocka
+//
+
+import SwiftUI
+
+struct StatusItemMenu: View {
+
+  // MARK: - Stored Properties
+
+  /// The app environment object.
+  @EnvironmentObject var appEnvironment: AppEnvironment
+
+  var didTapItem: Interaction?
+
+  var body: some View {
+    VStack(alignment: .leading) {
+      Button("Start Server") {
+        print("Start Server")
+        didTapItem?()
+      }
+      .disabled(appEnvironment.isServerRunning)
+      .buttonStyle(MenuBarButton())
+
+      Button("Stop Server") {
+        print("Stop Server")
+        didTapItem?()
+      }
+      .disabled(appEnvironment.isServerRunning.inverted())
+      .buttonStyle(MenuBarButton())
+
+      Button("Restart Server") {
+        print("Restart Server")
+        didTapItem?()
+      }
+      .disabled(appEnvironment.isServerRunning.inverted())
+      .buttonStyle(MenuBarButton())
+    }
+  }
+}
+
+struct MenuBarButton: ButtonStyle {
+  @Environment(\.isEnabled) private var isEnabled: Bool
+  @State var isHover = false
+
+  var foregroundColor: Color {
+    isEnabled ? .latte : .americano
+  }
+
+  var backgroundColor: Color {
+    isEnabled && isHover ? .americano : .clear
+  }
+
+  func makeBody(configuration: Configuration) -> some View {
+    configuration.label
+      .padding([.leading, .trailing], 5)
+      .frame(maxWidth: .infinity, alignment: .leading)
+      .background(backgroundColor)
+      .cornerRadius(3)
+      .padding([.leading, .trailing], 5)
+      .foregroundColor(foregroundColor)
+      .onHover(perform: { hovering in
+        isHover = hovering
+      })
+  }
+}
+
+struct StatusItemMenu_Previews: PreviewProvider {
+  static var previews: some View {
+    StatusItemMenu()
+      .previewLayout(.fixed(width: 200, height: 200))
+      .environmentObject(AppEnvironment())
+  }
+}


### PR DESCRIPTION
# Issue 

- https://github.com/wise-emotions/mocka/issues/97

# Description

This PR is an experiment to add the status bar icon on the right side of the top macOS bar.

We have tried two different approaches:
- Embedding a `SwiftUI` View inside the status item to recreate the menu. This solution has the advantage to use the `appEnvironment` and fetch the current state of the server to enable/disable Start and Stop server interactions when not available. This solution shows some bug when clicking the buttons when the app is in background.
- Using the old `AppKit` way of creating items inside the menu and linking an interaction for each item. This solution does not present the aforementioned bug, but the `appEnvironment` cannot be used.