### PR TITLE
Fix Editor SourceTree EmptyState visible NavigationLink button

### DIFF
--- a/Sources/App/Views/Sections/Editor/Detail/EditorDetail.swift
+++ b/Sources/App/Views/Sections/Editor/Detail/EditorDetail.swift
@@ -16,6 +16,8 @@ struct EditorDetail: View {
 
   var body: some View {
     VStack {
+      Divider()
+
       if viewModel.shouldShowEmptyState {
         EmptyState(symbol: .document, text: "Select a request to display its details")
       } else {

--- a/Sources/App/Views/Sections/Editor/SourceTree/SourceTree.swift
+++ b/Sources/App/Views/Sections/Editor/SourceTree/SourceTree.swift
@@ -20,20 +20,8 @@ struct SourceTree: View {
 
       if viewModel.isSourceTreeEmpty {
         EmptyState(symbol: .scroll, text: "Tap the 􀁌 to add an API request")
-          .background(
-            NavigationLink(
-              destination: EditorDetail(viewModel: viewModel.detailViewModel(for: nil)),
-              isActive: $viewModel.isShowingCreateRequestDetailView
-            ) {}
-          )
       } else if viewModel.filteredNodes.isEmpty {
         EmptyState(symbol: .document, text: "Could not find any API requests with this name")
-          .background(
-            NavigationLink(
-              destination: EditorDetail(viewModel: viewModel.detailViewModel(for: nil)),
-              isActive: $viewModel.isShowingCreateRequestDetailView
-            ) {}
-          )
       } else {
         List(viewModel.filteredNodes, children: \.children) { node in
           NavigationLink(destination: EditorDetail(viewModel: viewModel.detailViewModel(for: node))) {
@@ -63,15 +51,17 @@ struct SourceTree: View {
         }
         .listStyle(SidebarListStyle())
         .padding(.top, -8)
-        .background(
-          NavigationLink(
-            destination: EditorDetail(viewModel: viewModel.detailViewModel(for: nil)),
-            isActive: $viewModel.isShowingCreateRequestDetailView
-          ) {}
-        )
       }
     }
     .frame(minWidth: Size.minimumListWidth)
+    .background(
+      // This NavigationLink here is needed to show the detail for the creation of the request when the user tap on the `+` button.
+      NavigationLink(
+        destination: EditorDetail(viewModel: viewModel.detailViewModel(for: nil)),
+        isActive: $viewModel.isShowingCreateRequestDetailView
+      ) {}
+      .hidden()
+    )
     .toolbar {
       ToolbarItem {
         HStack {


### PR DESCRIPTION
# Description

This PR fixes the `NavigationLink` button visible in the background of the `EmptyStateView` of the `SourceTree` in the `Editor` section.

<img width="296" alt="Screenshot 2021-08-05 at 15 44 26" src="https://user-images.githubusercontent.com/23726138/128384344-8f1b3537-3cff-47b3-ac9e-0c224240ee6b.png">

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Manual testing.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
