### PR TITLE
Fix Editor Crash

### DIFF
--- a/Sources/App/Views/Sections/Editor/SourceTree/SourceTreeNode.swift
+++ b/Sources/App/Views/Sections/Editor/SourceTree/SourceTreeNode.swift
@@ -22,7 +22,7 @@ struct SourceTreeNode: View {
   // MARK: - Interaction
 
   /// The user renamed the node.
-  var onRenamed: ((String) -> Void)?
+  let onRenamed: (String) -> Void
 
   // MARK: - Body
 
@@ -37,7 +37,7 @@ struct SourceTreeNode: View {
           "Folder name", text: $name,
           onCommit: {
             if name.isNotEmpty {
-              onRenamed?(name)
+              onRenamed(name)
             }
           }
         )
@@ -62,7 +62,7 @@ struct SourceTreeNode: View {
   ///   - isFolder: Whether the node is a folder or not.
   ///   - isRenaming: Whether the node is being renamed.
   ///   - onRenamed: The closure invoked after renaming the node with the new name.
-  init(name: String, isFolder: Bool, isRenaming: Bool = false, onRenamed: ((String) -> Void)? = nil) {
+  init(name: String, isFolder: Bool, isRenaming: Bool = false, onRenamed: @escaping (String) -> Void) {
     self.name = name
     self.isFolder = isFolder
     self.isRenaming = isRenaming

--- a/project.yml
+++ b/project.yml
@@ -6,6 +6,8 @@ settings:
   TARGETED_DEVICE_FAMILY: 3
   # https://forums.swift.org/t/swift-packages-in-multiple-targets-results-in-this-will-result-in-duplication-of-library-code-errors/34892/36
   DISABLE_DIAMOND_PROBLEM_DIAGNOSTIC: true
+  # https://github.com/wise-emotions/mocka/issues/108
+  SWIFT_OPTIMIZATION_LEVEL: -Onone
 
 options:
   minimumXcodeGenVersion: "2.11.0"


### PR DESCRIPTION
# Description

This PR fixes an Editor crash when the user has at least 1 API in `release` mode.

Fixes #108

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [x] Open the app and go to the Editor section with at least 1 API

**Configuration**:
OS and Version: macOS 11.2.1
App Version: 0.1.0

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
